### PR TITLE
Improve onboarding docs for Python intro notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,107 @@
+# Python Introduction Guide
+
+A curated set of Jupyter notebooks and exercises that introduce the fundamentals of Python programming. Use this repository as a rapid study path or a refresher on the language, its standard library, and the data science ecosystem.
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Repository Structure](#repository-structure)
+3. [Getting Started](#getting-started)
+4. [Suggested Learning Path](#suggested-learning-path)
+5. [Python Quick Reference](#python-quick-reference)
+6. [Recommended Resources](#recommended-resources)
+
+## Overview
+
+The material is organised as a progression of notebooks that cover core Python concepts, common programming patterns, and introductory data science tools. Each topic combines explanations with hands-on code examples that you can execute and modify interactively.
+
+Key learning outcomes include:
+
+- Understanding Python syntax, data types, and control flow.
+- Writing reusable functions and working with modules.
+- Applying object-oriented and functional programming techniques.
+- Exploring data using NumPy, pandas, and Matplotlib.
+- Practising through incremental exercises that reinforce each concept.
+
+## Repository Structure
+
+| Path | Description |
+| --- | --- |
+| `README.md` | Quick start instructions and learning roadmap (this file). |
+| `requirements.txt` | Dependencies used throughout the notebooks (Jupyter, NumPy, pandas, Matplotlib, etc.). |
+| `docs/quick_reference.md` | One-page Python syntax cheat sheet to accompany the notebooks. |
+| `*.ipynb` | Standalone notebooks that introduce language fundamentals, OOP, functional programming, collections, and data libraries. |
+| `exercise/` | Practice notebooks organised by difficulty to consolidate the concepts from the main lessons. |
+
+> Tip: Open the notebooks in the suggested order below to get a smooth introduction. Feel free to jump around once you are comfortable with the basics.
+
+## Getting Started
+
+1. **Install Python 3.10+** (3.11 recommended).
+2. **Create and activate a virtual environment:**
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+   ```
+3. **Install the dependencies:**
+   ```bash
+   pip install --upgrade pip
+   pip install -r requirements.txt
+   ```
+4. **Launch JupyterLab or the classic notebook interface:**
+   ```bash
+   jupyter lab
+   # or
+   jupyter notebook
+   ```
+5. **Open the notebooks** listed below and run the cells sequentially. Use `Shift + Enter` to execute a cell.
+
+If you are new to virtual environments, review the [official documentation](https://docs.python.org/3/library/venv.html) for platform-specific details.
+
+## Suggested Learning Path
+
+1. **Python Foundations**
+   - `functions.ipynb`: syntax, indentation rules, variables, basic I/O.
+   - `comprension_colecciones.ipynb`: lists, tuples, dictionaries, sets, and comprehensions.
+   - `access_modifications.ipynb`: working with data structures and manipulating their contents.
+
+2. **Control Flow and Functional Patterns**
+   - `functional_programming.ipynb`: lambda functions, map/filter/reduce, iterators.
+   - `lamba.ipynb`: focused practice with anonymous functions and functional techniques.
+
+3. **Object-Oriented Programming**
+   - `objects.ipynb`: classes, instances, encapsulation.
+   - `herencia.ipynb`: inheritance, method overriding, polymorphism.
+   - `access_modifications.ipynb`: access modifiers, properties, and dataclasses.
+
+4. **Applied Python**
+   - `numpy.ipynb`: array operations and numerical computing.
+   - `pandas.ipynb`: tabular data manipulation and analysis.
+   - `matplotlib.ipynb`: data visualisation fundamentals.
+
+5. **Practice**
+   - Work through the notebooks in the `exercise/` directory. They align with the lessons above and provide progressively challenging problems.
+   - Revisit earlier notebooks if you need to reinforce a concept before moving forward.
+
+As you progress, take notes or adapt the examples into scripts to cement your understanding.
+
+## Python Quick Reference
+
+When you need a concise reminder of syntax and idioms, consult [`docs/quick_reference.md`](docs/quick_reference.md). It covers:
+
+- Common commands for running Python and managing virtual environments.
+- Core language features (strings, numbers, collections, control flow, functions).
+- Object-oriented programming patterns and error handling.
+- File I/O, testing strategies, and key data science libraries.
+
+Keep the cheat sheet open alongside the notebooks for quick lookups.
+
+## Recommended Resources
+
+- [Python Official Tutorial](https://docs.python.org/3/tutorial/)
+- [Real Python](https://realpython.com/) articles for deeper dives into specific topics.
+- [Automate the Boring Stuff with Python](https://automatetheboringstuff.com/) for practical automation projects.
+- [PEP 8 – Style Guide for Python Code](https://peps.python.org/pep-0008/) to write idiomatic code.
+- [pandas Documentation](https://pandas.pydata.org/docs/) and [NumPy Documentation](https://numpy.org/doc/) for data-focused workflows.
+
+Happy coding! Use this repository as your rapid Python refresher or starting point, and expand it with your own notebooks as you learn.

--- a/docs/quick_reference.md
+++ b/docs/quick_reference.md
@@ -1,0 +1,230 @@
+# Python Quick Reference
+
+This quick reference complements the Jupyter notebooks in this repository. Use it as a reminder of the core syntax and idioms you will encounter while working through the material.
+
+## 1. Python Basics
+
+### Running Python
+```bash
+python --version
+python -m pip install --upgrade pip
+python script.py
+python -i script.py  # run and drop into REPL
+```
+
+### Variables and Types
+```python
+message = "Hello"
+count = 10              # int
+ratio = 3.14            # float
+is_ready = True         # bool
+nothing = None          # NoneType
+```
+
+Python is dynamically typed. Use `type(value)` to inspect a value's type.
+
+### Strings
+```python
+name = "Ada"
+len(name)            # 3
+name.upper()         # 'ADA'
+"-".join(["a", "b"])  # 'a-b'
+"Value: {}".format(42)
+f"Value: {42}"
+```
+Use triple quotes for multiline strings.
+
+## 2. Numbers and Operators
+```python
+5 + 3    # addition
+5 // 3   # floor division
+5 % 3    # modulo
+5 ** 2   # exponentiation
+```
+Comparison operators return booleans (`==`, `!=`, `<`, `<=`, `>`, `>=`). Combine expressions with `and`, `or`, and `not`.
+
+## 3. Collections
+
+### Lists
+```python
+items = [1, 2, 3]
+items.append(4)
+items[0]          # 1
+items[-1]         # 4
+items[1:3]        # [2, 3]
+```
+
+### Tuples
+```python
+point = (3, 4)
+x, y = point
+```
+
+### Sets
+```python
+unique = {1, 2, 3}
+unique.add(2)      # unchanged
+unique | {3, 4}    # union: {1, 2, 3, 4}
+```
+
+### Dictionaries
+```python
+user = {"name": "Ada", "age": 37}
+user["name"]          # 'Ada'
+user.get("email", "")
+for key, value in user.items():
+    print(key, value)
+```
+
+### Comprehensions
+```python
+squares = [n**2 for n in range(5)]
+odd_squares = {n: n**2 for n in range(5) if n % 2}
+```
+
+## 4. Control Flow
+```python
+if score >= 90:
+    grade = "A"
+elif score >= 80:
+    grade = "B"
+else:
+    grade = "C"
+
+for n in range(5):
+    print(n)
+
+while condition:
+    do_something()
+
+for index, value in enumerate(items):
+    print(index, value)
+```
+Use `break`, `continue`, and `pass` when needed.
+
+## 5. Functions
+```python
+def greet(name: str, greeting: str = "Hello") -> str:
+    return f"{greeting}, {name}!"
+
+result = greet("Ada")
+```
+Functions are first-class objects. You can pass them as arguments or return them from other functions.
+
+### Lambda Functions
+```python
+add = lambda x, y: x + y
+```
+Use sparingly for simple one-line functions.
+
+### Higher-Order Functions
+```python
+numbers = [1, 2, 3]
+doubled = list(map(lambda n: n * 2, numbers))
+even = list(filter(lambda n: n % 2 == 0, numbers))
+from functools import reduce
+product = reduce(lambda acc, n: acc * n, numbers, 1)
+```
+
+## 6. Modules and Packages
+```python
+import math
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+```
+Use `if __name__ == "__main__":` to make scripts executable and importable.
+
+### Virtual Environments
+```bash
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+```
+
+## 7. Object-Oriented Programming
+```python
+class Animal:
+    def __init__(self, name: str):
+        self.name = name
+
+    def speak(self) -> str:
+        return "..."
+
+class Dog(Animal):
+    def speak(self) -> str:
+        return "Woof!"
+
+pet: Animal = Dog("Luna")
+pet.speak()  # 'Woof!'
+```
+Use properties to manage access and `@staticmethod`/`@classmethod` for alternative constructors.
+
+## 8. Error Handling
+```python
+try:
+    risky_operation()
+except ValueError as exc:
+    print(f"Invalid value: {exc}")
+else:
+    print("No exception raised")
+finally:
+    cleanup()
+```
+Raise exceptions with `raise ValueError("message")` when appropriate.
+
+## 9. Files and Context Managers
+```python
+from pathlib import Path
+
+path = Path("data.txt")
+path.write_text("hello")
+print(path.read_text())
+
+with path.open("a", encoding="utf-8") as fh:
+    fh.write("\nworld")
+```
+
+## 10. Testing and Quality
+```bash
+python -m unittest discover
+pytest
+ruff check .
+```
+Use type hints and `mypy` or `pyright` for static analysis.
+
+## 11. Data Science Essentials
+
+### NumPy
+```python
+import numpy as np
+
+arr = np.array([1, 2, 3])
+arr.mean()        # 2.0
+arr.reshape(3, 1)
+```
+
+### pandas
+```python
+import pandas as pd
+
+df = pd.DataFrame({"name": ["Ada", "Grace"], "age": [37, 36]})
+df["age"].mean()
+df[df["age"] > 36]
+```
+
+### Matplotlib
+```python
+import matplotlib.pyplot as plt
+
+plt.plot([1, 2, 3], [1, 4, 9])
+plt.title("Example")
+plt.show()
+```
+
+## 12. Next Steps
+
+* Explore the notebooks in this repository for in-depth explanations and exercises.
+* Practice writing small scripts and functions daily.
+* Read the official [Python tutorial](https://docs.python.org/3/tutorial/) and [PEP 8](https://peps.python.org/pep-0008/) style guide.


### PR DESCRIPTION
## Summary
- expand the README with an overview, setup steps, suggested notebook order, and resources
- add a Python quick reference cheat sheet to accompany the notebooks

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e26d48df648333bc4825c37c48e8ac